### PR TITLE
Fix ledger broadcast txn: encoding was incorrect

### DIFF
--- a/packages/extension/src/background/messaging/internalMethods.ts
+++ b/packages/extension/src/background/messaging/internalMethods.ts
@@ -613,7 +613,7 @@ export class InternalMethods {
 
             fetch(url, {
               method: 'POST',
-              body: JSON.stringify({ rawtxn: txnBuffer.toString('base64') }),
+              body: txnBuffer,
               headers: { 'Content-Type': 'application/x-binary' },
             })
               .then((response) => {


### PR DESCRIPTION
This fixes an issue when broadcasting ledger transactions initiated/signed from the extension

The transaction was encoded in a `{ rawtxn: base64(txn) }` format which did not work, not sure if it ever did or if there was a backwards breaking change at some point

Tested this fix with a Nano X and it submitted successfully